### PR TITLE
Add n0kovo_subdomains wordlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A curated list of wordlists for bruteforcing and fuzzing
 
 ## Other languages
 - [French wordlists](https://github.com/clem9669/wordlists)
-- [danish-wordlists](https://github.com/narkopolo/danish-wordlists) - Collection of danish base wordlists.
+- [danish-wordlists](https://github.com/n0kovo/danish-wordlists) - Collection of danish base wordlists.
 - [albanian-wordlist](https://github.com/its0x08/albanian-wordlist) - Albanian wordlist - A mix of names, last names and some albanian literature.
 
 ## Miscellaneous

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A curated list of wordlists for bruteforcing and fuzzing
 - [Directories](https://github.com/xajkep/wordlists/blob/master/discovery/directory_only_one.small.txt) - xajkep's directories
 - [Backup files](https://github.com/xajkep/wordlists/blob/master/discovery/backup_files_only.txt) - xajkep's backup files
 - [Backup files with path](https://github.com/xajkep/wordlists/blob/master/discovery/backup_files_with_path.txt) - xajkep's backup files with paths
+- [n0kovo_subdomains](https://github.com/n0kovo/n0kovo_subdomains) - An extremely effective subdomain wordlist of 3,000,000 lines, crafted by harvesting SSL certs from the entire IPv4 space.
 
 ## Emails
 - [Xajkep's email providers](https://github.com/xajkep/wordlists/blob/master/misc/email_free_providers.txt) - Email providers from xajkep's wordlists


### PR DESCRIPTION
Hi, I've added my own subdomain wordlist to the list.

I wrote a blog post about it here:
https://n0kovo.github.io/posts/subdomain-enumeration-creating-a-highly-efficient-wordlist-by-scanning-the-entire-internet/