### PR TITLE
Add items to passwords & usernames lists

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ Thank you so much for everyone who helped make this list better!
 - [P1YUSH](https://github.com/piyush-security/)
 - [iam-py-test](https://github.com/iam-py-test/)
 - [itsmohitnarayan](https://github.com/itsmohitnarayan/)
+- [keyboardslap](https://github.com/keyboardslap/)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A curated list of wordlists for bruteforcing and fuzzing.
 - [SecLists' Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords) - Password wordlists from SecLists.
 - [CrackStation](https://crackstation.net/crackstation-wordlist-password-cracking-dictionary.htm) - CrackStation's password wordlist.
 - [Active-Directory-Wordlists' Passwords](https://github.com/Cryilllic/Active-Directory-Wordlists/blob/master/Pass.txt) - Most common Active-Directory passwords.
+- [Weakpass](https://weakpass.com/wordlist) -  Collection of >1500 password wordlists. 
 
 ## Usernames
 - [SecLists' Usernames](https://github.com/danielmiessler/SecLists/tree/master/Usernames) - Username wordlists from SecLists.
@@ -86,3 +87,4 @@ Thank you so much to everyone who helped make this list better!
 - [P1YUSH](https://github.com/piyush-security/)
 - [iam-py-test](https://github.com/iam-py-test/)
 - [itsmohitnarayan](https://github.com/itsmohitnarayan/)
+- [keyboardslap](https://github.com/keyboardslap/)

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ A curated list of wordlists for bruteforcing and fuzzing.
 - [SecLists' Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords) - Password wordlists from SecLists.
 - [CrackStation](https://crackstation.net/crackstation-wordlist-password-cracking-dictionary.htm) - CrackStation's password wordlist.
 - [Active-Directory-Wordlists' Passwords](https://github.com/Cryilllic/Active-Directory-Wordlists/blob/master/Pass.txt) - Most common Active-Directory passwords.
-- [Weakpass](https://weakpass.com/wordlist) -  Collection of more than 1500 password wordlists. 
+- [Weakpass](https://weakpass.com/wordlist) -  Collection of more than 1500 password wordlists with torrent links for faster downloads. 
 
 ## Usernames
 - [SecLists' Usernames](https://github.com/danielmiessler/SecLists/tree/master/Usernames) - Username wordlists from SecLists.
 - [Active-Directory-Wordlists' Users](https://github.com/Cryilllic/Active-Directory-Wordlists/blob/master/User.txt) - Most common Active-Directory usernames.
+- [fbnames](https://infocon.org/word%20lists/fbnames.rar) - Names of Facebook users from 2010. 
 
 ## Vulnerabilities 
 - [NoSQL-Injection Wordlist](https://github.com/cr0hn/nosqlinjection_wordlists/blob/master/mongodb_nosqli.txt) - List of payloads to test NoSQL Injections.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A curated list of wordlists for bruteforcing and fuzzing.
 - [SecLists' Passwords](https://github.com/danielmiessler/SecLists/tree/master/Passwords) - Password wordlists from SecLists.
 - [CrackStation](https://crackstation.net/crackstation-wordlist-password-cracking-dictionary.htm) - CrackStation's password wordlist.
 - [Active-Directory-Wordlists' Passwords](https://github.com/Cryilllic/Active-Directory-Wordlists/blob/master/Pass.txt) - Most common Active-Directory passwords.
-- [Weakpass](https://weakpass.com/wordlist) -  Collection of >1500 password wordlists. 
+- [Weakpass](https://weakpass.com/wordlist) -  Collection of more than 1500 password wordlists. 
 
 ## Usernames
 - [SecLists' Usernames](https://github.com/danielmiessler/SecLists/tree/master/Usernames) - Username wordlists from SecLists.


### PR DESCRIPTION
Add Weakpass to the list of password wordlists. It contains just about every password wordlist already mentioned in this repo. It also provides torrent links for its wordlists, enabling faster downloads (which are necessary since some of these wordlists are dozens of GBs compressed). 

Add fbnames to the list of usernames. According to infocon.org, it was collected from skullsecurity.org in 2010, but it's no longer available there. Other wordlists on infocon.org are, as far as I can tell, also present on Weakpass. As this is technically a list of names and not usernames, I understand if you'd like it removed or in a different section of readme.md. 